### PR TITLE
make aws keys optional (for use IAM S3 role)

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -4,6 +4,17 @@ require "refile"
 require "refile/s3/version"
 
 module Refile
+
+  # @api private
+  class S3BackendError < StandardError; end
+
+  # @api private
+  class S3CredentialsError < S3BackendError
+    def message
+      "Credentials not found"
+    end
+  end
+
   # A refile backend which stores files in Amazon S3
   #
   # @example
@@ -17,9 +28,9 @@ module Refile
   class S3
     extend Refile::BackendMacros
 
-    attr_reader :max_size
+    attr_reader :access_key_id, :max_size
 
-    # Sets up an S3 backend with the given credentials.
+    # Sets up an S3 backend
     #
     # @param [String] region            The AWS region to connect to
     # @param [String] bucket            The name of the bucket where files will be stored
@@ -32,6 +43,9 @@ module Refile
     def initialize(region:, bucket:, max_size: nil, prefix: nil, hasher: Refile::RandomHasher.new, **s3_options)
       @s3_options = { region: region }.merge s3_options
       @s3 = Aws::S3::Resource.new @s3_options
+      credentials = @s3.client.config.credentials
+      raise S3CredentialsError unless credentials
+      @access_key_id = credentials.access_key_id
       @bucket_name = bucket
       @bucket = @s3.bucket @bucket_name
       @hasher = hasher
@@ -46,7 +60,7 @@ module Refile
     verify_uploadable def upload(uploadable)
       id = @hasher.hash(uploadable)
 
-      if uploadable.is_a?(Refile::File) and uploadable.backend.is_a?(S3)
+      if uploadable.is_a?(Refile::File) and uploadable.backend.is_a?(S3) and uploadable.backend.access_key_id == access_key_id
         object(id).copy_from(copy_source: [@bucket_name, uploadable.backend.object(uploadable.id).key].join("/"))
       else
         object(id).put(body: uploadable, content_length: uploadable.size)


### PR DESCRIPTION
close #1
- Use with IAM role:

```
# config/initializers/refile.rb
require "refile/s3"
aws = {
  region: "sa-east-1",
  bucket: "my-bucket",
}

Refile.cache = Refile::S3.new(prefix: "cache", **aws)
Refile.store = Refile::S3.new(prefix: "store", **aws)
```
- Use without IAM role (no changes):

```
# config/initializers/refile.rb
require "refile/s3"

aws = {
  access_key_id: "xyz",
  secret_access_key: "abc",
  region: "sa-east-1",
  bucket: "my-bucket",
}
Refile.cache = Refile::S3.new(prefix: "cache", **aws)
Refile.store = Refile::S3.new(prefix: "store", **aws)
```
