### PR TITLE
S3 object options

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -32,9 +32,9 @@ module Refile
 
     S3_AVAILABLE_OPTIONS = {
       client: %i(access_key_id region secret_access_key),
-      copy_from: %i(copy_source server_side_encryption),
-      presigned_post: %i(key server_side_encryption),
-      put: %i(body content_length server_side_encryption)
+      copy_from: %i(copy_source server_side_encryption storage_class),
+      presigned_post: %i(key server_side_encryption storage_class),
+      put: %i(body content_length server_side_encryption storage_class)
     }
 
     # Sets up an S3 backend

--- a/spec/refile/s3_spec.rb
+++ b/spec/refile/s3_spec.rb
@@ -3,10 +3,49 @@ require "refile/s3"
 
 WebMock.allow_net_connect!
 
-config = YAML.load_file("s3.yml").map { |k, v| [k.to_sym, v] }.to_h
+s3_config = YAML.load_file("s3.yml").map { |k, v| [k.to_sym, v] }.to_h
 
 RSpec.describe Refile::S3 do
+  let(:config) { s3_config }
   let(:backend) { Refile::S3.new(max_size: 100, **config) }
 
   it_behaves_like :backend
+
+  describe '@s3_options' do
+    let(:value) { backend.instance_variable_get(:@s3_options) }
+
+    it 'is initialized' do
+      %i(access_key_id secret_access_key region).each do |attribute|
+        expect(value[attribute]).to eq(config[attribute])
+      end
+    end
+  end
+
+  %i(s3_object_operation_options s3_presigned_post_options).each do |option|
+    describe "@#{option}" do
+      let(:additional_config) do
+        { "#{option}".to_sym => { server_side_encryption: 'aes256' } }
+      end
+
+      let(:config) { additional_config.merge s3_config }
+      let(:value) { backend.send(:instance_variable_get, "@#{option}") }
+
+      it 'is initialized' do
+        expect(value[:server_side_encryption]).to eq('aes256')
+        expect(backend.instance_variable_get(:@s3_options)).not_to have_key(option)
+      end
+    end
+
+    describe ".#{option}" do
+      let(:additional_config) do
+        { "#{option}".to_sym => { server_side_encryption: 'aes256' } }
+      end
+
+      let(:config) { additional_config.merge s3_config }
+
+      it 'is merges provided options' do
+        expect(backend.send(option, { server_side_encryption: 'aws:kms' })[:server_side_encryption]).to eq('aws:kms')
+      end
+    end
+  end
 end

--- a/spec/refile/s3_spec.rb
+++ b/spec/refile/s3_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe Refile::S3 do
         secret_access_key: 'abcd1234',
         region: 'sa-east-1',
         bucket: 'my-bucket',
-        server_side_encryption: 'aes256'
+        server_side_encryption: 'aes256',
+        storage_class: 'STANDARD'
       }
     end
     let(:options) { {} }
@@ -62,7 +63,8 @@ RSpec.describe Refile::S3 do
         it 'returns valid options' do
           expect(value).to eq(
             copy_source: 'xyz',
-            server_side_encryption: 'aes256'
+            server_side_encryption: 'aes256',
+            storage_class: 'STANDARD'
           )
         end
       end
@@ -74,7 +76,8 @@ RSpec.describe Refile::S3 do
         it 'returns valid options' do
           expect(value).to eq(
             key: 'xyz',
-            server_side_encryption: 'aes256'
+            server_side_encryption: 'aes256',
+            storage_class: 'STANDARD'
           )
         end
       end
@@ -87,7 +90,8 @@ RSpec.describe Refile::S3 do
           expect(value).to eq(
             body: 'xyz',
             content_length: 3,
-            server_side_encryption: 'aes256'
+            server_side_encryption: 'aes256',
+            storage_class: 'STANDARD'
           )
         end
       end


### PR DESCRIPTION
Issue refile/refile-s3#3

Provides `server_side_encryption` and `storage_class` configuration options.

I was unable to get the test suite to pass tests regarding non-existing files, but this was from the get go, so I don't believe my changes caused that regression.

PS. If this approach is acceptable, but you'd like a nicer commit history I can squash the commits and create a new PR.
