### PR TITLE
Add ability to use non-https S3-compatible backends

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -95,7 +95,7 @@ module Refile
     # @param [String] id           The id of the file
     # @return [IO]                An IO object containing the file contents
     verify_id def open(id)
-      Kernel.open(object(id).presigned_url(:get))
+      Kernel.open(object(id).presigned_url(:get, secure: secure_endpoint))
     end
 
     # Return the entire contents of the uploaded file as a String.
@@ -137,6 +137,10 @@ module Refile
     def clear!(confirm = nil)
       raise Refile::Confirm unless confirm == :confirm
       @bucket.objects(prefix: @prefix).delete
+    end
+
+    def secure_endpoint
+      @s3_options.fetch(:endpoint, "").starts_with? "https"
     end
 
     # Return a presign signature which can be used to upload a file into this


### PR DESCRIPTION
I've got the following exception with Riak CS + refile-s3 setup: 

```
E, [2015-11-16T15:35:23.209989 #47340] ERROR -- : Refile::App: Error -> Connection refused - connect(2) for "test-bucket.some-domain.com" port 443
E, [2015-11-16T15:35:23.211056 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/net/http.rb:879:in `initialize'
E, [2015-11-16T15:35:23.211299 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/net/http.rb:879:in `open'
E, [2015-11-16T15:35:23.211358 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/net/http.rb:879:in `block in connect'
E, [2015-11-16T15:35:23.211492 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/timeout.rb:73:in `timeout'
E, [2015-11-16T15:35:23.211530 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/net/http.rb:878:in `connect'
E, [2015-11-16T15:35:23.211598 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/net/http.rb:863:in `do_start'
E, [2015-11-16T15:35:23.211640 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/net/http.rb:852:in `start'
E, [2015-11-16T15:35:23.211680 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/open-uri.rb:318:in `open_http'
E, [2015-11-16T15:35:23.211734 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/open-uri.rb:736:in `buffer_open'
E, [2015-11-16T15:35:23.211760 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/open-uri.rb:211:in `block in open_loop'
E, [2015-11-16T15:35:23.211783 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/open-uri.rb:209:in `catch'
E, [2015-11-16T15:35:23.211808 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/open-uri.rb:209:in `open_loop'
E, [2015-11-16T15:35:23.211896 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/open-uri.rb:150:in `open_uri'
E, [2015-11-16T15:35:23.211927 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/open-uri.rb:716:in `open'
E, [2015-11-16T15:35:23.212021 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/open-uri.rb:34:in `open'
E, [2015-11-16T15:35:23.212059 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/refile-s3-0.2.0/lib/refile/s3.rb:98:in `open'
E, [2015-11-16T15:35:23.212082 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/refile-0.6.2/lib/refile/backend_macros.rb:11:in `block (2 levels) in verify_id'
E, [2015-11-16T15:35:23.212117 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/refile-0.6.2/lib/refile/file.rb:89:in `io'
E, [2015-11-16T15:35:23.212155 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/refile-0.6.2/lib/refile/file.rb:70:in `download'
E, [2015-11-16T15:35:23.212221 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/refile-0.6.2/lib/refile/app.rb:154:in `file'
E, [2015-11-16T15:35:23.212498 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/refile-0.6.2/lib/refile/app.rb:42:in `block in <class:App>'
E, [2015-11-16T15:35:23.212527 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1610:in `call'
E, [2015-11-16T15:35:23.212545 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1610:in `block in compile!'
E, [2015-11-16T15:35:23.212559 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `[]'
E, [2015-11-16T15:35:23.212574 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `block (3 levels) in route!'
E, [2015-11-16T15:35:23.212588 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:993:in `route_eval'
E, [2015-11-16T15:35:23.212627 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `block (2 levels) in route!'
E, [2015-11-16T15:35:23.212641 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1014:in `block in process_route'
E, [2015-11-16T15:35:23.212654 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1012:in `catch'
E, [2015-11-16T15:35:23.212667 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1012:in `process_route'
E, [2015-11-16T15:35:23.212680 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:972:in `block in route!'
E, [2015-11-16T15:35:23.212693 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:971:in `each'
E, [2015-11-16T15:35:23.212706 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:971:in `route!'
E, [2015-11-16T15:35:23.212719 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1084:in `block in dispatch!'
E, [2015-11-16T15:35:23.212732 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `block in invoke'
E, [2015-11-16T15:35:23.212744 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `catch'
E, [2015-11-16T15:35:23.212757 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `invoke'
E, [2015-11-16T15:35:23.212770 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1081:in `dispatch!'
E, [2015-11-16T15:35:23.212806 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:906:in `block in call!'
E, [2015-11-16T15:35:23.212819 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `block in invoke'
E, [2015-11-16T15:35:23.212832 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `catch'
E, [2015-11-16T15:35:23.212858 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `invoke'
E, [2015-11-16T15:35:23.212874 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:906:in `call!'
E, [2015-11-16T15:35:23.212886 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:894:in `call'
E, [2015-11-16T15:35:23.212899 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/refile-0.6.2/lib/refile/custom_logger.rb:16:in `call'
E, [2015-11-16T15:35:23.212912 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-protection-1.5.3/lib/rack/protection/xss_header.rb:18:in `call'
E, [2015-11-16T15:35:23.212925 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-protection-1.5.3/lib/rack/protection/path_traversal.rb:16:in `call'
E, [2015-11-16T15:35:23.212938 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-protection-1.5.3/lib/rack/protection/json_csrf.rb:18:in `call'
E, [2015-11-16T15:35:23.212950 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
E, [2015-11-16T15:35:23.212963 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
E, [2015-11-16T15:35:23.212976 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-protection-1.5.3/lib/rack/protection/frame_options.rb:31:in `call'
E, [2015-11-16T15:35:23.212989 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/nulllogger.rb:9:in `call'
E, [2015-11-16T15:35:23.213028 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/head.rb:13:in `call'
E, [2015-11-16T15:35:23.213041 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:181:in `call'
E, [2015-11-16T15:35:23.213054 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/sinatra-1.4.6/lib/sinatra/base.rb:2021:in `call'
E, [2015-11-16T15:35:23.213067 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/routing/mapper.rb:51:in `serve'
E, [2015-11-16T15:35:23.213080 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/journey/router.rb:43:in `block in serve'
E, [2015-11-16T15:35:23.213092 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/journey/router.rb:30:in `each'
E, [2015-11-16T15:35:23.213105 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/journey/router.rb:30:in `serve'
E, [2015-11-16T15:35:23.213118 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/routing/route_set.rb:821:in `call'
E, [2015-11-16T15:35:23.213130 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/omniauth-1.2.2/lib/omniauth/strategy.rb:186:in `call!'
E, [2015-11-16T15:35:23.213143 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/omniauth-1.2.2/lib/omniauth/strategy.rb:164:in `call'
E, [2015-11-16T15:35:23.213156 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/omniauth-1.2.2/lib/omniauth/strategy.rb:186:in `call!'
E, [2015-11-16T15:35:23.213168 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/omniauth-1.2.2/lib/omniauth/strategy.rb:164:in `call'
E, [2015-11-16T15:35:23.213181 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/omniauth-1.2.2/lib/omniauth/strategy.rb:186:in `call!'
E, [2015-11-16T15:35:23.213194 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/omniauth-1.2.2/lib/omniauth/strategy.rb:164:in `call'
E, [2015-11-16T15:35:23.213223 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/http_accept_language-2.0.5/lib/http_accept_language/middleware.rb:14:in `call'
E, [2015-11-16T15:35:23.213241 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/warden-1.2.3/lib/warden/manager.rb:35:in `block in call'
E, [2015-11-16T15:35:23.213255 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/warden-1.2.3/lib/warden/manager.rb:34:in `catch'
E, [2015-11-16T15:35:23.213268 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/warden-1.2.3/lib/warden/manager.rb:34:in `call'
E, [2015-11-16T15:35:23.213281 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/etag.rb:24:in `call'
E, [2015-11-16T15:35:23.213293 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/conditionalget.rb:25:in `call'
E, [2015-11-16T15:35:23.213306 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/head.rb:13:in `call'
E, [2015-11-16T15:35:23.213319 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/middleware/params_parser.rb:27:in `call'
E, [2015-11-16T15:35:23.213332 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/middleware/flash.rb:260:in `call'
E, [2015-11-16T15:35:23.213357 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:225:in `context'
E, [2015-11-16T15:35:23.213371 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/session/abstract/id.rb:220:in `call'
E, [2015-11-16T15:35:23.213384 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/middleware/cookies.rb:560:in `call'
E, [2015-11-16T15:35:23.213397 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/activerecord-4.2.4/lib/active_record/query_cache.rb:36:in `call'
E, [2015-11-16T15:35:23.213409 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/activerecord-4.2.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:653:in `call'
E, [2015-11-16T15:35:23.213423 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
E, [2015-11-16T15:35:23.213446 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/callbacks.rb:88:in `__run_callbacks__'
E, [2015-11-16T15:35:23.213509 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/callbacks.rb:778:in `_run_call_callbacks'
E, [2015-11-16T15:35:23.213535 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/callbacks.rb:81:in `run_callbacks'
E, [2015-11-16T15:35:23.213555 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/middleware/callbacks.rb:27:in `call'
E, [2015-11-16T15:35:23.213569 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/middleware/remote_ip.rb:78:in `call'
E, [2015-11-16T15:35:23.213583 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
E, [2015-11-16T15:35:23.213606 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
E, [2015-11-16T15:35:23.213632 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/railties-4.2.4/lib/rails/rack/logger.rb:38:in `call_app'
E, [2015-11-16T15:35:23.213647 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/railties-4.2.4/lib/rails/rack/logger.rb:20:in `block in call'
E, [2015-11-16T15:35:23.213660 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/tagged_logging.rb:68:in `block in tagged'
E, [2015-11-16T15:35:23.213679 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/tagged_logging.rb:26:in `tagged'
E, [2015-11-16T15:35:23.213693 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/tagged_logging.rb:68:in `tagged'
E, [2015-11-16T15:35:23.213706 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/railties-4.2.4/lib/rails/rack/logger.rb:20:in `call'
E, [2015-11-16T15:35:23.213718 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/request_store-1.2.0/lib/request_store/middleware.rb:8:in `call'
E, [2015-11-16T15:35:23.213731 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/actionpack-4.2.4/lib/action_dispatch/middleware/request_id.rb:21:in `call'
E, [2015-11-16T15:35:23.213764 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/methodoverride.rb:22:in `call'
E, [2015-11-16T15:35:23.213785 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/runtime.rb:18:in `call'
E, [2015-11-16T15:35:23.213800 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/activesupport-4.2.4/lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
E, [2015-11-16T15:35:23.213813 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/lock.rb:17:in `call'
E, [2015-11-16T15:35:23.213825 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/sendfile.rb:113:in `call'
E, [2015-11-16T15:35:23.213838 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/railties-4.2.4/lib/rails/engine.rb:518:in `call'
E, [2015-11-16T15:35:23.213850 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/railties-4.2.4/lib/rails/application.rb:165:in `call'
E, [2015-11-16T15:35:23.213862 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/lock.rb:17:in `call'
E, [2015-11-16T15:35:23.213875 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/content_length.rb:15:in `call'
E, [2015-11-16T15:35:23.213888 #47340] ERROR -- : Refile::App: /usr/local/lib/ruby/gems/2.2.0/gems/rack-1.6.4/lib/rack/handler/webrick.rb:88:in `service'
E, [2015-11-16T15:35:23.213900 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
E, [2015-11-16T15:35:23.213931 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
E, [2015-11-16T15:35:23.213944 #47340] ERROR -- : Refile::App: /usr/local/Cellar/ruby/2.2.3/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
I, [2015-11-16T15:35:23.214312 #47340]  INFO -- : Refile::App: [2015-11-16 15:35:23 +0500] GET "/697a297a392a9def14f5786eff562aafd672ae81/store/6370580eb6ca07cf48f92f9f80a5a99024d26c7a1fc096f49f3b5054e203/logo.png" 500 522.7ms

```

Problem was in `presigned_url` call, which uses HTTPS by default. If we define endpoint with `http://` scheme explicitly, `presigned_url` should be called with `secure: false`.
