### PR TITLE
fix deprecated call to Aws::CredentialProvider access_key_id

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -43,7 +43,7 @@ module Refile
     def initialize(region:, bucket:, max_size: nil, prefix: nil, hasher: Refile::RandomHasher.new, **s3_options)
       @s3_options = { region: region }.merge s3_options
       @s3 = Aws::S3::Resource.new @s3_options
-      credentials = @s3.client.config.credentials
+      credentials = @s3.client.config.credentials.credentials
       raise S3CredentialsError unless credentials
       @access_key_id = credentials.access_key_id
       @bucket_name = bucket


### PR DESCRIPTION
This @s3.client.config.credentials is SharedCredentials, which included methods from CredentialProvider:
http://docs.aws.amazon.com/sdkforruby/api/Aws/CredentialProvider.html#access_key_id-instance_method

Instead this methods, we must use this methods from Credentials module:
http://docs.aws.amazon.com/sdkforruby/api/Aws/Credentials.html#access_key_id-instance_method
