### PR TITLE
Remove required :region from Refile::S3.new

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -40,8 +40,8 @@ module Refile
     # @param [Hash] s3_options          Additional options to initialize S3 with
     # @see http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/Core/Configuration.html
     # @see http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/S3.html
-    def initialize(region:, bucket:, max_size: nil, prefix: nil, hasher: Refile::RandomHasher.new, **s3_options)
-      @s3_options = { region: region }.merge s3_options
+    def initialize(bucket:, max_size: nil, prefix: nil, hasher: Refile::RandomHasher.new, **s3_options)
+      @s3_options = s3_options
       @s3 = Aws::S3::Resource.new @s3_options
       credentials = @s3.client.config.credentials
       raise S3CredentialsError unless credentials

--- a/refile-s3.gemspec
+++ b/refile-s3.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.1.0"
+  spec.required_ruby_version = ">= 2.2.3"
 
   spec.add_dependency "refile", "~> 0.6.0"
   spec.add_dependency "aws-sdk", "~> 2.0"


### PR DESCRIPTION
The AWS SDK knows how to pull this info from env vars and standard config files, so best to avoid making the constructor aware of it.

This change is backwards compatible in terms of interface for the constructor.

That being said, this change breaks on `ruby 2.2.2p95` in a strange way, so bumped the Ruby version requirement.
