### PR TITLE
Use Object#get instead of Kernel::open to get object from backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 *.a
 mkmf.log
 s3.yml
+.ruby-version
+.ruby-gemset

--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -95,7 +95,9 @@ module Refile
     # @param [String] id           The id of the file
     # @return [IO]                An IO object containing the file contents
     verify_id def open(id)
-      Kernel.open(object(id).presigned_url(:get))
+      object(id).get.body
+    rescue Aws::S3::Errors::NoSuchKey
+      nil
     end
 
     # Return the entire contents of the uploaded file as a String.


### PR DESCRIPTION
Hello. Firstly, thank you for this gem. It saved me a lot of time a few months back when trying to work with Ceph as the backend. Today I realized that I forgot to submit this PR as a change needed to make the gem work with backends that use self-signed certs (such as those in dev environments). I'm submitting this for your review/approval.

Commit message follows:

This change uses the object instance directly to get the file from the backend instead of using a presigned URL to get it. Presigning was not necessary in this method since the URL doesn't get passed on to the client anyway. Also, by avoiding Kernel::open, we avoid having to manage certificate stores in both `aws-sdk` and `open-uri`.
