### PR TITLE
Fix AWS::CredentialProvider deprecation warning

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -28,7 +28,7 @@ module Refile
   class S3
     extend Refile::BackendMacros
 
-    attr_reader :access_key_id, :max_size
+    attr_reader :max_size
 
     # Sets up an S3 backend
     #
@@ -45,7 +45,6 @@ module Refile
       @s3 = Aws::S3::Resource.new @s3_options
       credentials = @s3.client.config.credentials
       raise S3CredentialsError unless credentials
-      @access_key_id = credentials.access_key_id
       @bucket_name = bucket
       @bucket = @s3.bucket @bucket_name
       @hasher = hasher
@@ -60,7 +59,7 @@ module Refile
     verify_uploadable def upload(uploadable)
       id = @hasher.hash(uploadable)
 
-      if uploadable.is_a?(Refile::File) and uploadable.backend.is_a?(S3) and uploadable.backend.access_key_id == access_key_id
+      if uploadable.is_a?(Refile::File) and uploadable.backend.is_a?(S3) 
         object(id).copy_from(copy_source: [@bucket_name, uploadable.backend.object(uploadable.id).key].join("/"))
       else
         object(id).put(body: uploadable, content_length: uploadable.size)


### PR DESCRIPTION
This fixes a noisy deprecation warning from the AWS when using IAM instance profiles (e.g., not providing `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. Error below. 

```
DEPRECATION WARNING: called deprecated method `access_key_id' of an Aws::CredentialProvider, use #credentials instead
/usr/local/bundle/gems/refile-s3-0.2.0/lib/refile/s3.rb:48:in `initialize'
/able/config/initializers/refile.rb:47:in `new'
/able/config/initializers/refile.rb:47:in `<top (required)>'
/usr/local/bundle/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:268:in `load'
/usr/local/bundle/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:268:in `block in load'
/usr/local/bundle/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:240:in `load_dependency'
/usr/local/bundle/gems/activesupport-4.2.7.1/lib/active_support/dependencies.rb:268:in `load'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/engine.rb:652:in `block in load_config_initializer'
/usr/local/bundle/gems/activesupport-4.2.7.1/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/engine.rb:651:in `load_config_initializer'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/engine.rb:616:in `block (2 levels) in <class:Engine>'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/engine.rb:615:in `each'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/engine.rb:615:in `block in <class:Engine>'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/initializable.rb:30:in `instance_exec'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/initializable.rb:30:in `run'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/initializable.rb:55:in `block in run_initializers'
/usr/lib/ruby/2.3.0/tsort.rb:228:in `block in tsort_each'
/usr/lib/ruby/2.3.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
/usr/lib/ruby/2.3.0/tsort.rb:422:in `block (2 levels) in each_strongly_connected_component_from'
/usr/lib/ruby/2.3.0/tsort.rb:431:in `each_strongly_connected_component_from'
/usr/lib/ruby/2.3.0/tsort.rb:421:in `block in each_strongly_connected_component_from'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/initializable.rb:44:in `each'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/initializable.rb:44:in `tsort_each_child'
/usr/lib/ruby/2.3.0/tsort.rb:415:in `call'
/usr/lib/ruby/2.3.0/tsort.rb:415:in `each_strongly_connected_component_from'
/usr/lib/ruby/2.3.0/tsort.rb:349:in `block in each_strongly_connected_component'
/usr/lib/ruby/2.3.0/tsort.rb:347:in `each'
/usr/lib/ruby/2.3.0/tsort.rb:347:in `call'
/usr/lib/ruby/2.3.0/tsort.rb:347:in `each_strongly_connected_component'
/usr/lib/ruby/2.3.0/tsort.rb:226:in `tsort_each'
/usr/lib/ruby/2.3.0/tsort.rb:205:in `tsort_each'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/initializable.rb:54:in `run_initializers'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/application.rb:352:in `initialize!'
/able/config/environment.rb:16:in `<top (required)>'
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/application.rb:328:in `require_environment!'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:142:in `require_application_and_environment!'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:67:in `console'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
/usr/local/bundle/gems/railties-4.2.7.1/lib/rails/commands.rb:17:in `<top (required)>'
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
bin/rails:4:in `<main>'
```
