### PR TITLE
Remove prefixed s3 from client endpoint

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -43,6 +43,7 @@ module Refile
     def initialize(region:, bucket:, max_size: nil, prefix: nil, hasher: Refile::RandomHasher.new, **s3_options)
       @s3_options = { region: region }.merge s3_options
       @s3 = Aws::S3::Resource.new @s3_options
+      @s3.client.config.endpoint = URI("https://#{region}.amazonaws.com")
       credentials = @s3.client.config.credentials
       raise S3CredentialsError unless credentials
       @access_key_id = credentials.access_key_id


### PR DESCRIPTION
When trying to upload a file I get the following error: 

```
Seahorse::Client::NetworkingError: hostname "bucket-name.s3.s3-eu-west-1.amazonaws.com" does not match the server certificate
```

This is basically because the url should be `bucket-name.s3-eu-west-1.amazonaws.com`. As you can see the correct url doesn't contain the `.s3.` after the bucket name and before the region. 

After some debugging og the `@s3.client.config` I can see that there is an `endpoint`, which is set to `URI("https://s3.#{region}.amazonaws.com")`.

Setting this to `URI("https://#{region}.amazonaws.com")` fixes this problem.
