### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -1,4 +1,4 @@
-require "aws-sdk"
+require "aws-sdk-s3"
 require "open-uri"
 require "refile"
 require "refile/s3/version"

--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -136,7 +136,7 @@ module Refile
     # @return [void]
     def clear!(confirm = nil)
       raise Refile::Confirm unless confirm == :confirm
-      @bucket.objects(prefix: @prefix).delete
+      @bucket.objects(prefix: @prefix).batch_delete!
     end
 
     # Return a presign signature which can be used to upload a file into this

--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -28,7 +28,7 @@ module Refile
   class S3
     extend Refile::BackendMacros
 
-    attr_reader :access_key_id, :max_size
+    attr_reader :access_key_id, :max_size, :bucket_name
 
     # Sets up an S3 backend
     #
@@ -43,7 +43,7 @@ module Refile
     def initialize(region:, bucket:, max_size: nil, prefix: nil, hasher: Refile::RandomHasher.new, **s3_options)
       @s3_options = { region: region }.merge s3_options
       @s3 = Aws::S3::Resource.new @s3_options
-      credentials = @s3.client.config.credentials
+      credentials = @s3.client.config.credentials.credentials
       raise S3CredentialsError unless credentials
       @access_key_id = credentials.access_key_id
       @bucket_name = bucket
@@ -61,7 +61,7 @@ module Refile
       id = @hasher.hash(uploadable)
 
       if uploadable.is_a?(Refile::File) and uploadable.backend.is_a?(S3) and uploadable.backend.access_key_id == access_key_id
-        object(id).copy_from(copy_source: [@bucket_name, uploadable.backend.object(uploadable.id).key].join("/"))
+        object(id).copy_from(copy_source: [uploadable.backend.bucket_name, uploadable.backend.object(uploadable.id).key].join("/"))
       else
         object(id).put(body: uploadable, content_length: uploadable.size)
       end

--- a/lib/refile/s3/version.rb
+++ b/lib/refile/s3/version.rb
@@ -1,5 +1,5 @@
 module Refile
   class S3
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/lib/refile/s3/version.rb
+++ b/lib/refile/s3/version.rb
@@ -1,5 +1,5 @@
 module Refile
   class S3
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end

--- a/refile-s3.gemspec
+++ b/refile-s3.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.1.0"
 
   spec.add_dependency "refile", "~> 0.6.0"
-  spec.add_dependency "aws-sdk", "~> 2.0"
+  spec.add_dependency "aws-sdk-s3", "~> 1"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/refile-s3.gemspec
+++ b/refile-s3.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1.0"
 
-  spec.add_dependency "refile", "~> 0.6.0"
-  spec.add_dependency "aws-sdk-s3", "~> 1.13"
+  spec.add_dependency "refile", "~> 0.7.0"
+  spec.add_dependency "aws-sdk-s3", "~> 1"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Didn't know how to contribute to #29 so here's another PR. This brings use of AWS SDK up-to-date, removes all deprecation warnings but should keep direct S3-to-S3 copy feature intact.
